### PR TITLE
Add human-readable uid + fix failing tests

### DIFF
--- a/stick_emulator/helpers.py
+++ b/stick_emulator/helpers.py
@@ -1,9 +1,0 @@
-
-def flatten_nested_list(nested_list:list) -> list:
-    flat_list = []
-    for item in nested_list:
-        if isinstance(item, list):
-            flat_list.extend(flatten_nested_list(item))
-        else:
-            flat_list.append(item)
-    return flat_list

--- a/stick_emulator/networks/connecting/synchronizer.py
+++ b/stick_emulator/networks/connecting/synchronizer.py
@@ -20,10 +20,7 @@ class SynchronizerNetwork(SpikingNetworkModule):
         Tsyn = 1.0
 
         # Create sync neuron
-        self.sync = ExplicitNeuron(
-            Vt=Vt, tm=tm, tf=tf, Vreset=0.0, neuron_id="sync"
-        )
-        self.add_neurons(self.sync)
+        self.sync = self.add_neuron(Vt=Vt, tm=tm, tf=tf, Vreset=0.0, neuron_name="sync")
 
         self.input_neurons = []
         self.output_neurons = []
@@ -31,13 +28,12 @@ class SynchronizerNetwork(SpikingNetworkModule):
 
         for i in range(N):
             # Input and output interface neurons
-            input_neuron = ExplicitNeuron(
-                Vt=Vt, tm=tm, tf=tf, Vreset=0.0, neuron_id=f"input_{i}"
+            input_neuron = self.add_neuron(
+                Vt=Vt, tm=tm, tf=tf, Vreset=0.0, neuron_name=f"input_{i}"
             )
-            output_neuron = ExplicitNeuron(
-                Vt=Vt, tm=tm, tf=tf, Vreset=0.0, neuron_id=f"output_{i}"
+            output_neuron = self.add_neuron(
+                Vt=Vt, tm=tm, tf=tf, Vreset=0.0, neuron_name=f"output_{i}"
             )
-            self.add_neurons([input_neuron, output_neuron])
             self.input_neurons.append(input_neuron)
             self.output_neurons.append(output_neuron)
 
@@ -53,9 +49,7 @@ class SynchronizerNetwork(SpikingNetworkModule):
             self.connect_neurons(memory.output, output_neuron, "V", we, Tsyn)
 
             # Connect memory.ready to sync
-            self.connect_neurons(
-                memory.ready, self.sync, "V", (we / N) + 0.0001, Tsyn
-            )
+            self.connect_neurons(memory.ready, self.sync, "V", (we / N) + 0.0001, Tsyn)
 
             # Connect sync to memory.recall
             self.connect_neurons(self.sync, memory.recall, "V", we, Tsyn)

--- a/stick_emulator/networks/functional/exponential.py
+++ b/stick_emulator/networks/functional/exponential.py
@@ -24,15 +24,11 @@ class ExponentialNetwork(SpikingNetworkModule):
         wacc = Vt * tm / encoder.Tcod  # To ensure V = Vt at Tcod
 
         # Neurons
-        self.input = ExplicitNeuron(Vt, tm, tf, neuron_id=prefix + "_input")
-        self.first = ExplicitNeuron(Vt, tm, tf, neuron_id=prefix + "_first")
-        self.last = ExplicitNeuron(Vt, tm, tf, neuron_id=prefix + "_last")
-        self.acc = ExplicitNeuron(Vt, tm, tf, neuron_id=prefix + "_acc")
-        self.output = ExplicitNeuron(Vt, tm, tf, neuron_id=prefix + "_output")
-
-        self.add_neurons(
-            [self.input, self.first, self.last, self.acc, self.output]
-        )
+        self.input = self.add_neuron(Vt, tm, tf, neuron_name=prefix + "_input")
+        self.first = self.add_neuron(Vt, tm, tf, neuron_name=prefix + "_first")
+        self.last = self.add_neuron(Vt, tm, tf, neuron_name=prefix + "_last")
+        self.acc = self.add_neuron(Vt, tm, tf, neuron_name=prefix + "_acc")
+        self.output = self.add_neuron(Vt, tm, tf, neuron_name=prefix + "_output")
 
         # Connections from input neuron
         self.connect_neurons(self.input, self.first, "V", we, Tsyn)
@@ -78,16 +74,16 @@ if __name__ == "__main__":
     from stick_emulator import Simulator
 
     encoder = DataEncoder(Tmin=10.0, Tcod=100.0)
-    net = ExpNetwork(encoder)
+    net = ExponentialNetwork(encoder)
 
     value = 0.2
     sim = Simulator(net, encoder, dt=0.01)
     sim.apply_input_value(value, neuron=net.input, t0=10)
     sim.simulate(300)
 
-    output_spikes = sim.spike_log.get(net.output.id, [])
-    acc_spikes = sim.spike_log.get(net.acc.id, [])
-    last_spike = sim.spike_log.get(net.last.id, [None])[-1]
+    output_spikes = sim.spike_log.get(net.output.uid, [])
+    acc_spikes = sim.spike_log.get(net.acc.uid, [])
+    last_spike = sim.spike_log.get(net.last.uid, [None])[-1]
     print(output_spikes)
     print(f"Input value: {value}")
     print(f"Expected exp delay: {expected_exp_output_delay(value):.3f} ms")

--- a/stick_emulator/networks/functional/integrator.py
+++ b/stick_emulator/networks/functional/integrator.py
@@ -33,30 +33,26 @@ class IntegratorNetwork(SpikingNetworkModule):
         gmult = (Vt * tm) / tf
         wacc = (Vt * tm) / encoder.Tcod
 
-        self.init = ExplicitNeuron(Vt=Vt, tm=tm, tf=tf, neuron_id="init")
+        self.init = self.add_neuron(Vt=Vt, tm=tm, tf=tf, neuron_name="init")
 
-        self.input_plus = ExplicitNeuron(
-            Vt=Vt, tm=tm, tf=tf, neuron_id=prefix + "input_plus"
+        self.input_plus = self.add_neuron(
+            Vt=Vt, tm=tm, tf=tf, neuron_name=prefix + "input_plus"
         )
-        self.input_minus = ExplicitNeuron(
-            Vt=Vt, tm=tm, tf=tf, neuron_id=prefix + "input_minus"
+        self.input_minus = self.add_neuron(
+            Vt=Vt, tm=tm, tf=tf, neuron_name=prefix + "input_minus"
         )
-        self.start = ExplicitNeuron(
-            Vt=Vt, tm=tm, tf=tf, neuron_id=prefix + "start"
+        self.start = self.add_neuron(Vt=Vt, tm=tm, tf=tf, neuron_name=prefix + "start")
+        self.output_plus = self.add_neuron(
+            Vt=Vt, tm=tm, tf=tf, neuron_name=prefix + "output_plus"
         )
-        self.output_plus = ExplicitNeuron(
-            Vt=Vt, tm=tm, tf=tf, neuron_id=prefix + "output_plus"
+        self.output_minus = self.add_neuron(
+            Vt=Vt, tm=tm, tf=tf, neuron_name=prefix + "output_minus"
         )
-        self.output_minus = ExplicitNeuron(
-            Vt=Vt, tm=tm, tf=tf, neuron_id=prefix + "output_minus"
-        )
-        self.new_input = ExplicitNeuron(
-            Vt=Vt, tm=tm, tf=tf, neuron_id=prefix + "new_input"
+        self.new_input = self.add_neuron(
+            Vt=Vt, tm=tm, tf=tf, neuron_name=prefix + "new_input"
         )
 
-        self.constant_network = SignedConstantNetwork(
-            encoder, constant, prefix + "sc"
-        )
+        self.constant_network = SignedConstantNetwork(encoder, constant, prefix + "sc")
         self.lin_comb = LinearCombinatorNetwork(
             encoder, 2, coeffs, prefix=prefix + "lin_comb"
         )
@@ -64,9 +60,7 @@ class IntegratorNetwork(SpikingNetworkModule):
         self.add_subnetwork(self.constant_network)
         self.add_subnetwork(self.lin_comb)
 
-        self.connect_neurons(
-            self.init, self.constant_network.recall, "V", we, Tsyn
-        )
+        self.connect_neurons(self.init, self.constant_network.recall, "V", we, Tsyn)
 
         self.connect_neurons(
             self.input_plus, self.lin_comb.input_neurons[2], "V", we, Tsyn
@@ -75,9 +69,7 @@ class IntegratorNetwork(SpikingNetworkModule):
             self.input_minus, self.lin_comb.input_neurons[3], "V", we, Tsyn
         )
 
-        self.connect_neurons(
-            self.start, self.lin_comb.input_neurons[2], "V", we, Tsyn
-        )
+        self.connect_neurons(self.start, self.lin_comb.input_neurons[2], "V", we, Tsyn)
         self.connect_neurons(
             self.start, self.lin_comb.input_neurons[2], "V", we, Tsyn + Tmin
         )
@@ -112,9 +104,7 @@ class IntegratorNetwork(SpikingNetworkModule):
             Tsyn,
         )
 
-        self.connect_neurons(
-            self.lin_comb.output_plus, self.output_plus, "V", we, Tsyn
-        )
+        self.connect_neurons(self.lin_comb.output_plus, self.output_plus, "V", we, Tsyn)
         self.connect_neurons(
             self.lin_comb.output_minus, self.output_minus, "V", we, Tsyn
         )
@@ -152,8 +142,8 @@ if __name__ == "__main__":
     sim.simulate(800)
 
     # Decode final output
-    output_plus = sim.spike_log.get(net.output_plus.id, [])
-    output_minus = sim.spike_log.get(net.output_minus.id, [])
+    output_plus = sim.spike_log.get(net.output_plus.uid, [])
+    output_minus = sim.spike_log.get(net.output_minus.uid, [])
 
     if len(output_plus) >= 2:
         interval = output_plus[1] - output_plus[0]

--- a/stick_emulator/networks/functional/linear_combinator.py
+++ b/stick_emulator/networks/functional/linear_combinator.py
@@ -10,9 +10,7 @@ import math
 
 
 class LinearCombinatorNetwork(SpikingNetworkModule):
-    def __init__(
-        self, encoder: DataEncoder, N: int, coeff: list, prefix: str = ""
-    ):
+    def __init__(self, encoder: DataEncoder, N: int, coeff: list, prefix: str = ""):
         super().__init__()
         self.encoder = encoder
 
@@ -28,36 +26,32 @@ class LinearCombinatorNetwork(SpikingNetworkModule):
         gmult = (Vt * tm) / tf
         wacc = (Vt * tm) / encoder.Tcod
 
-        self.acc1_plus = ExplicitNeuron(
-            Vt=Vt, tm=tm, tf=tf, neuron_id=prefix + "_acc1_plus"
+        self.acc1_plus = self.add_neuron(
+            Vt=Vt, tm=tm, tf=tf, neuron_name=prefix + "_acc1_plus"
         )
-        self.acc1_minus = ExplicitNeuron(
-            Vt=Vt, tm=tm, tf=tf, neuron_id=prefix + "_acc1_minus"
+        self.acc1_minus = self.add_neuron(
+            Vt=Vt, tm=tm, tf=tf, neuron_name=prefix + "_acc1_minus"
         )
-        self.acc2_plus = ExplicitNeuron(
-            Vt=Vt, tm=tm, tf=tf, neuron_id=prefix + "_acc2_plus"
+        self.acc2_plus = self.add_neuron(
+            Vt=Vt, tm=tm, tf=tf, neuron_name=prefix + "_acc2_plus"
         )
-        self.acc2_minus = ExplicitNeuron(
-            Vt=Vt, tm=tm, tf=tf, neuron_id=prefix + "_acc2_minus"
+        self.acc2_minus = self.add_neuron(
+            Vt=Vt, tm=tm, tf=tf, neuron_name=prefix + "_acc2_minus"
         )
-        self.inter_minus = ExplicitNeuron(
-            Vt=Vt, tm=tm, tf=tf, neuron_id=prefix + "_inter_minus"
+        self.inter_minus = self.add_neuron(
+            Vt=Vt, tm=tm, tf=tf, neuron_name=prefix + "_inter_minus"
         )
-        self.inter_plus = ExplicitNeuron(
-            Vt=Vt, tm=tm, tf=tf, neuron_id=prefix + "_inter_plus"
+        self.inter_plus = self.add_neuron(
+            Vt=Vt, tm=tm, tf=tf, neuron_name=prefix + "_inter_plus"
         )
-        self.output_plus = ExplicitNeuron(
-            Vt=Vt, tm=tm, tf=tf, neuron_id=prefix + "_output_plus"
+        self.output_plus = self.add_neuron(
+            Vt=Vt, tm=tm, tf=tf, neuron_name=prefix + "_output_plus"
         )
-        self.output_minus = ExplicitNeuron(
-            Vt=Vt, tm=tm, tf=tf, neuron_id=prefix + "_output_minus"
+        self.output_minus = self.add_neuron(
+            Vt=Vt, tm=tm, tf=tf, neuron_name=prefix + "_output_minus"
         )
-        self.start = ExplicitNeuron(
-            Vt=Vt, tm=tm, tf=tf, neuron_id=prefix + "_start"
-        )
-        self.sync = ExplicitNeuron(
-            Vt=Vt, tm=tm, tf=tf, neuron_id=prefix + "_sync"
-        )
+        self.start = self.add_neuron(Vt=Vt, tm=tm, tf=tf, neuron_name=prefix + "_start")
+        self.sync = self.add_neuron(Vt=Vt, tm=tm, tf=tf, neuron_name=prefix + "_sync")
 
         self.sync_network = SynchronizerNetwork(encoder, 2)
         self.subtractor_network = SubtractorNetwork(encoder)
@@ -120,29 +114,9 @@ class LinearCombinatorNetwork(SpikingNetworkModule):
         # Connect acc1- to inter- with V synapse and Tsyn
         self.connect_neurons(self.acc1_minus, self.inter_minus, "V", we, Tsyn)
         # Connect acc2+ to inter+ with V synapse and Tsyn + Tmin
-        self.connect_neurons(
-            self.acc2_plus, self.inter_plus, "V", we, Tsyn + Tmin
-        )
+        self.connect_neurons(self.acc2_plus, self.inter_plus, "V", we, Tsyn + Tmin)
         # Connect acc2- to inter- with V synapse and Tsyn + Tmin
-        self.connect_neurons(
-            self.acc2_minus, self.inter_minus, "V", we, Tsyn + Tmin
-        )
-
-        # Add these neurons
-        self.add_neurons(
-            [
-                self.acc1_plus,
-                self.acc1_minus,
-                self.acc2_plus,
-                self.acc2_minus,
-                self.inter_minus,
-                self.inter_plus,
-                self.output_plus,
-                self.output_minus,
-                self.start,
-                self.sync,
-            ]
-        )
+        self.connect_neurons(self.acc2_minus, self.inter_minus, "V", we, Tsyn + Tmin)
 
         self.input_neurons = []
 
@@ -152,35 +126,25 @@ class LinearCombinatorNetwork(SpikingNetworkModule):
             a_i = abs(a_i)
             # Create input +/- neurons
             input_plus = ExplicitNeuron(
-                Vt=Vt, tm=tm, tf=tf, neuron_id=f"input_plus_{i}"
+                Vt=Vt, tm=tm, tf=tf, neuron_name=f"input_plus_{i}"
             )
             input_minus = ExplicitNeuron(
-                Vt=Vt, tm=tm, tf=tf, neuron_id=f"input_minus_{i}"
+                Vt=Vt, tm=tm, tf=tf, neuron_name=f"input_minus_{i}"
             )
             # Create first and last +/-
             first_plus = ExplicitNeuron(
-                Vt=Vt, tm=tm, tf=tf, neuron_id=f"first_plus_{i}"
+                Vt=Vt, tm=tm, tf=tf, neuron_name=f"first_plus_{i}"
             )
             first_minus = ExplicitNeuron(
-                Vt=Vt, tm=tm, tf=tf, neuron_id=f"first_minus_{i}"
+                Vt=Vt, tm=tm, tf=tf, neuron_name=f"first_minus_{i}"
             )
             last_plus = ExplicitNeuron(
-                Vt=Vt, tm=tm, tf=tf, neuron_id=f"last_plus_{i}"
+                Vt=Vt, tm=tm, tf=tf, neuron_name=f"last_plus_{i}"
             )
             last_minus = ExplicitNeuron(
-                Vt=Vt, tm=tm, tf=tf, neuron_id=f"last_minus_{i}"
+                Vt=Vt, tm=tm, tf=tf, neuron_name=f"last_minus_{i}"
             )
 
-            self.add_neurons(
-                [
-                    input_plus,
-                    input_minus,
-                    first_plus,
-                    first_minus,
-                    last_plus,
-                    last_minus,
-                ]
-            )
             self.input_neurons.append(input_plus)
             self.input_neurons.append(input_minus)
 
@@ -203,17 +167,13 @@ class LinearCombinatorNetwork(SpikingNetworkModule):
             self.connect_neurons(
                 first_plus, self.acc1_plus, "ge", a_i * wacc, Tsyn + Tmin
             )
-            self.connect_neurons(
-                last_plus, self.acc1_plus, "ge", -a_i * wacc, Tsyn
-            )
+            self.connect_neurons(last_plus, self.acc1_plus, "ge", -a_i * wacc, Tsyn)
 
             # Connect first_minus with ge to acc1_minus where weight is |a_i|*wacc
             self.connect_neurons(
                 first_minus, self.acc1_minus, "ge", a_i * wacc, Tsyn + Tmin
             )
-            self.connect_neurons(
-                last_minus, self.acc1_minus, "ge", -a_i * wacc, Tsyn
-            )
+            self.connect_neurons(last_minus, self.acc1_minus, "ge", -a_i * wacc, Tsyn)
 
 
 def decode_spike_interval(spikes, encoder):
@@ -242,13 +202,9 @@ def run_test(coeffs, inputs, Tmin=10.0, Tcod=100.0):
     for i, val in enumerate(inputs):
         product = coeffs[i] * inputs[i]
         if product >= 0:
-            sim.apply_input_value(
-                abs(inputs[i]), net.input_neurons[2 * i], t0=0
-            )
+            sim.apply_input_value(abs(inputs[i]), net.input_neurons[2 * i], t0=0)
         else:
-            sim.apply_input_value(
-                abs(inputs[i]), net.input_neurons[2 * i + 1], t0=0
-            )
+            sim.apply_input_value(abs(inputs[i]), net.input_neurons[2 * i + 1], t0=0)
 
     sim.simulate(500)
 
@@ -257,8 +213,8 @@ def run_test(coeffs, inputs, Tmin=10.0, Tcod=100.0):
     expected = sum(c * x for c, x in zip(coeffs, inputs))
     print(f"✅ Expected linear combination: {expected:.3f}")
 
-    plus_spikes = sim.spike_log.get(net.output_plus.id, [])
-    minus_spikes = sim.spike_log.get(net.output_minus.id, [])
+    plus_spikes = sim.spike_log.get(net.output_plus.uid, [])
+    minus_spikes = sim.spike_log.get(net.output_minus.uid, [])
 
     decoded_plus = decode_spike_interval(plus_spikes, encoder)
     decoded_minus = decode_spike_interval(minus_spikes, encoder)

--- a/stick_emulator/networks/functional/multiplier.py
+++ b/stick_emulator/networks/functional/multiplier.py
@@ -23,55 +23,31 @@ class MultiplierNetwork(SpikingNetworkModule):
         gmult = (Vt * tm) / tf
 
         # Neurons
-        self.input1 = ExplicitNeuron(Vt, tm, tf, neuron_id=prefix + "input1")
-        self.input2 = ExplicitNeuron(Vt, tm, tf, neuron_id=prefix + "input2")
-        self.first1 = ExplicitNeuron(Vt, tm, tf, neuron_id=prefix + "first1")
-        self.last1 = ExplicitNeuron(Vt, tm, tf, neuron_id=prefix + "last1")
-        self.acc_log1 = ExplicitNeuron(
-            Vt, tm, tf, neuron_id=prefix + "acc_log1"
-        )
+        self.input1 = self.add_neuron(Vt, tm, tf, neuron_name=prefix + "input1")
+        self.input2 = self.add_neuron(Vt, tm, tf, neuron_name=prefix + "input2")
+        self.first1 = self.add_neuron(Vt, tm, tf, neuron_name=prefix + "first1")
+        self.last1 = self.add_neuron(Vt, tm, tf, neuron_name=prefix + "last1")
+        self.acc_log1 = self.add_neuron(Vt, tm, tf, neuron_name=prefix + "acc_log1")
 
-        self.first2 = ExplicitNeuron(Vt, tm, tf, neuron_id=prefix + "first2")
-        self.last2 = ExplicitNeuron(Vt, tm, tf, neuron_id=prefix + "last2")
-        self.acc_log2 = ExplicitNeuron(
-            Vt, tm, tf, neuron_id=prefix + "acc_log2"
-        )
+        self.first2 = self.add_neuron(Vt, tm, tf, neuron_name=prefix + "first2")
+        self.last2 = self.add_neuron(Vt, tm, tf, neuron_name=prefix + "last2")
+        self.acc_log2 = self.add_neuron(Vt, tm, tf, neuron_name=prefix + "acc_log2")
 
-        self.sync = ExplicitNeuron(Vt, tm, tf, neuron_id=prefix + "sync")
-        self.acc_exp = ExplicitNeuron(Vt, tm, tf, neuron_id=prefix + "acc_exp")
-        self.output = ExplicitNeuron(Vt, tm, tf, neuron_id=prefix + "output")
-
-        self.add_neurons(
-            [
-                self.input1,
-                self.input2,
-                self.first1,
-                self.last1,
-                self.acc_log1,
-                self.first2,
-                self.last2,
-                self.acc_log2,
-                self.sync,
-                self.acc_exp,
-                self.output,
-            ]
-        )
+        self.sync = self.add_neuron(Vt, tm, tf, neuron_name=prefix + "sync")
+        self.acc_exp = self.add_neuron(Vt, tm, tf, neuron_name=prefix + "acc_exp")
+        self.output = self.add_neuron(Vt, tm, tf, neuron_name=prefix + "output")
 
         self.connect_neurons(self.input1, self.first1, "V", we, Tsyn)
         self.connect_neurons(self.input1, self.last1, "V", 0.5 * we, Tsyn)
         self.connect_neurons(self.first1, self.first1, "V", wi, Tsyn)
-        self.connect_neurons(
-            self.first1, self.acc_log1, "ge", wacc, Tsyn + Tmin
-        )
+        self.connect_neurons(self.first1, self.acc_log1, "ge", wacc, Tsyn + Tmin)
         self.connect_neurons(self.last1, self.acc_log1, "ge", -wacc, Tsyn)
         self.connect_neurons(self.last1, self.sync, "V", 0.5 * we, Tsyn)
 
         self.connect_neurons(self.input2, self.first2, "V", we, Tsyn)
         self.connect_neurons(self.input2, self.last2, "V", 0.5 * we, Tsyn)
         self.connect_neurons(self.first2, self.first2, "V", wi, Tsyn)
-        self.connect_neurons(
-            self.first2, self.acc_log2, "ge", wacc, Tsyn + Tmin
-        )
+        self.connect_neurons(self.first2, self.acc_log2, "ge", wacc, Tsyn + Tmin)
         self.connect_neurons(self.last2, self.acc_log2, "ge", -wacc, Tsyn)
         self.connect_neurons(self.last2, self.sync, "V", 0.5 * we, Tsyn)
 
@@ -109,7 +85,7 @@ if __name__ == "__main__":
     # Simulate long enough to see output
     sim.simulate(simulation_time=400)
 
-    spikes = sim.spike_log.get(net.output.id, [])
+    spikes = sim.spike_log.get(net.output.uid, [])
 
     if len(spikes) >= 2:
         interval = spikes[1] - spikes[0]

--- a/stick_emulator/networks/functional/natural_log.py
+++ b/stick_emulator/networks/functional/natural_log.py
@@ -23,24 +23,12 @@ class LogNetwork(SpikingNetworkModule):
         wacc = (Vt * tm) / encoder.Tcod
 
         # Neurons
-        self.input = ExplicitNeuron(
-            Vt=Vt, tm=tm, tf=tf, neuron_id=prefix + "_input"
-        )
-        self.first = ExplicitNeuron(
-            Vt=Vt, tm=tm, tf=tf, neuron_id=prefix + "_first"
-        )
-        self.last = ExplicitNeuron(
-            Vt=Vt, tm=tm, tf=tf, neuron_id=prefix + "_last"
-        )
-        self.acc = ExplicitNeuron(
-            Vt=Vt, tm=tm, tf=tf, neuron_id=prefix + "_acc"
-        )
-        self.output = ExplicitNeuron(
-            Vt=Vt, tm=tm, tf=tf, neuron_id=prefix + "_output"
-        )
-
-        self.add_neurons(
-            [self.input, self.first, self.last, self.acc, self.output]
+        self.input = self.add_neuron(Vt=Vt, tm=tm, tf=tf, neuron_name=prefix + "_input")
+        self.first = self.add_neuron(Vt=Vt, tm=tm, tf=tf, neuron_name=prefix + "_first")
+        self.last = self.add_neuron(Vt=Vt, tm=tm, tf=tf, neuron_name=prefix + "_last")
+        self.acc = self.add_neuron(Vt=Vt, tm=tm, tf=tf, neuron_name=prefix + "_acc")
+        self.output = self.add_neuron(
+            Vt=Vt, tm=tm, tf=tf, neuron_name=prefix + "_output"
         )
 
         # Input triggers
@@ -87,24 +75,18 @@ if __name__ == "__main__":
     sim.apply_input_value(val, neuron=lognet.input, t0=10)
     sim.simulate(300)
 
-    output_spikes = sim.spike_log.get(lognet.output.id, [])
-    acc_spikes = sim.spike_log.get(lognet.acc.id, [])
-    last_spike_time = sim.spike_log.get(lognet.last.id, [None])[-1]
+    output_spikes = sim.spike_log.get(lognet.output.uid, [])
+    acc_spikes = sim.spike_log.get(lognet.acc.uid, [])
+    last_spike_time = sim.spike_log.get(lognet.last.uid, [None])[-1]
 
     print(f"Input value: {val}")
-    print(
-        f"Expected delay (log({val})): {expected_log_output_delay(val):.3f} ms"
-    )
+    print(f"Expected delay (log({val})): {expected_log_output_delay(val):.3f} ms")
 
     if len(output_spikes) >= 2:
         interval = output_spikes[1] - output_spikes[0]
         print(f"✅ Output spike interval: {interval:.3f} ms")
     elif len(output_spikes) == 1:
-        delay = (
-            output_spikes[0] - last_spike_time
-            if last_spike_time
-            else float("nan")
-        )
+        delay = output_spikes[0] - last_spike_time if last_spike_time else float("nan")
         print(
             f"✅ Output spike at: {output_spikes[0]:.3f} ms (delay from 'last': {delay:.3f} ms)"
         )

--- a/stick_emulator/networks/functional/signed_multiplier.py
+++ b/stick_emulator/networks/functional/signed_multiplier.py
@@ -25,45 +25,30 @@ class SignedMultiplierNetwork(SpikingNetworkModule):
         self.mn = MultiplierNetwork(encoder, prefix=prefix)
         self.add_subnetwork(self.mn)
 
-        self.input1_plus = ExplicitNeuron(
-            Vt, tm, tf, neuron_id=prefix + "input1_plus"
+        self.input1_plus = self.add_neuron(
+            Vt, tm, tf, neuron_name=prefix + "input1_plus"
         )
-        self.input1_minus = ExplicitNeuron(
-            Vt, tm, tf, neuron_id=prefix + "input1_minus"
+        self.input1_minus = self.add_neuron(
+            Vt, tm, tf, neuron_name=prefix + "input1_minus"
         )
-        self.input2_plus = ExplicitNeuron(
-            Vt, tm, tf, neuron_id=prefix + "input2_plus"
+        self.input2_plus = self.add_neuron(
+            Vt, tm, tf, neuron_name=prefix + "input2_plus"
         )
-        self.input2_minus = ExplicitNeuron(
-            Vt, tm, tf, neuron_id=prefix + "input2_minus"
-        )
-
-        self.output_plus = ExplicitNeuron(
-            Vt, tm, tf, neuron_id=prefix + "output_plus"
-        )
-        self.output_minus = ExplicitNeuron(
-            Vt, tm, tf, neuron_id=prefix + "output_minus"
+        self.input2_minus = self.add_neuron(
+            Vt, tm, tf, neuron_name=prefix + "input2_minus"
         )
 
-        self.sign1 = ExplicitNeuron(Vt, tm, tf, neuron_id=prefix + "sign1")
-        self.sign2 = ExplicitNeuron(Vt, tm, tf, neuron_id=prefix + "sign2")
-        self.sign3 = ExplicitNeuron(Vt, tm, tf, neuron_id=prefix + "sign3")
-        self.sign4 = ExplicitNeuron(Vt, tm, tf, neuron_id=prefix + "sign4")
-
-        self.add_neurons(
-            [
-                self.input1_plus,
-                self.input1_minus,
-                self.input2_plus,
-                self.input2_minus,
-                self.output_plus,
-                self.output_minus,
-                self.sign1,
-                self.sign2,
-                self.sign3,
-                self.sign4,
-            ]
+        self.output_plus = self.add_neuron(
+            Vt, tm, tf, neuron_name=prefix + "output_plus"
         )
+        self.output_minus = self.add_neuron(
+            Vt, tm, tf, neuron_name=prefix + "output_minus"
+        )
+
+        self.sign1 = self.add_neuron(Vt, tm, tf, neuron_name=prefix + "sign1")
+        self.sign2 = self.add_neuron(Vt, tm, tf, neuron_name=prefix + "sign2")
+        self.sign3 = self.add_neuron(Vt, tm, tf, neuron_name=prefix + "sign3")
+        self.sign4 = self.add_neuron(Vt, tm, tf, neuron_name=prefix + "sign4")
 
         self.connect_neurons(self.input1_plus, self.mn.input1, "V", we, Tsyn)
         self.connect_neurons(self.input1_minus, self.mn.input1, "V", wi, Tsyn)
@@ -74,22 +59,14 @@ class SignedMultiplierNetwork(SpikingNetworkModule):
         self.connect_neurons(self.input1_plus, self.sign1, "V", 0.25 * we, Tsyn)
         self.connect_neurons(self.input1_plus, self.sign3, "V", 0.25 * we, Tsyn)
 
-        self.connect_neurons(
-            self.input1_minus, self.sign2, "V", 0.25 * we, Tsyn
-        )
-        self.connect_neurons(
-            self.input1_minus, self.sign4, "V", 0.25 * we, Tsyn
-        )
+        self.connect_neurons(self.input1_minus, self.sign2, "V", 0.25 * we, Tsyn)
+        self.connect_neurons(self.input1_minus, self.sign4, "V", 0.25 * we, Tsyn)
 
         self.connect_neurons(self.input2_plus, self.sign1, "V", 0.25 * we, Tsyn)
         self.connect_neurons(self.input2_plus, self.sign2, "V", 0.25 * we, Tsyn)
 
-        self.connect_neurons(
-            self.input2_minus, self.sign3, "V", 0.25 * we, Tsyn
-        )
-        self.connect_neurons(
-            self.input2_minus, self.sign4, "V", 0.25 * we, Tsyn
-        )
+        self.connect_neurons(self.input2_minus, self.sign3, "V", 0.25 * we, Tsyn)
+        self.connect_neurons(self.input2_minus, self.sign4, "V", 0.25 * we, Tsyn)
 
         self.connect_neurons(self.sign1, self.sign2, "V", wi, Tsyn)
         self.connect_neurons(self.sign1, self.sign3, "V", 0.5 * wi, Tsyn)

--- a/stick_emulator/networks/functional/subtractor.py
+++ b/stick_emulator/networks/functional/subtractor.py
@@ -22,34 +22,19 @@ class SubtractorNetwork(SpikingNetworkModule):
         wi = -Vt
 
         # Create all neurons
-        self.input1 = ExplicitNeuron(Vt, tm, tf, neuron_id="input1")
-        self.input2 = ExplicitNeuron(Vt, tm, tf, neuron_id="input2")
+        self.input1 = self.add_neuron(Vt, tm, tf, neuron_name="input1")
+        self.input2 = self.add_neuron(Vt, tm, tf, neuron_name="input2")
 
-        self.sync1 = ExplicitNeuron(Vt, tm, tf, neuron_id="sync1")
-        self.sync2 = ExplicitNeuron(Vt, tm, tf, neuron_id="sync2")
+        self.sync1 = self.add_neuron(Vt, tm, tf, neuron_name="sync1")
+        self.sync2 = self.add_neuron(Vt, tm, tf, neuron_name="sync2")
 
-        self.inb1 = ExplicitNeuron(Vt, tm, tf, neuron_id="inb1")
-        self.inb2 = ExplicitNeuron(Vt, tm, tf, neuron_id="inb2")
+        self.inb1 = self.add_neuron(Vt, tm, tf, neuron_name="inb1")
+        self.inb2 = self.add_neuron(Vt, tm, tf, neuron_name="inb2")
 
-        self.output_plus = ExplicitNeuron(Vt, tm, tf, neuron_id="output_plus")
-        self.output_minus = ExplicitNeuron(Vt, tm, tf, neuron_id="output_minus")
+        self.output_plus = self.add_neuron(Vt, tm, tf, neuron_name="output_plus")
+        self.output_minus = self.add_neuron(Vt, tm, tf, neuron_name="output_minus")
 
-        self.zero = ExplicitNeuron(Vt, tm, tf, neuron_id="zero")
-
-        # Add all neurons
-        self.add_neurons(
-            [
-                self.input1,
-                self.input2,
-                self.sync1,
-                self.sync2,
-                self.inb1,
-                self.inb2,
-                self.output_plus,
-                self.output_minus,
-                self.zero,
-            ]
-        )
+        self.zero = self.add_neuron(Vt, tm, tf, neuron_name="zero")
 
         # --- Main black synapse pathway ---
         # Inputs to syncs
@@ -71,9 +56,7 @@ class SubtractorNetwork(SpikingNetworkModule):
             self.sync2, self.output_minus, "V", we, Tmin + (3 * Tsyn + 2 * Tneu)
         )
 
-        self.connect_neurons(
-            self.sync2, self.output_plus, "V", we, 3 * Tsyn + 2 * Tneu
-        )
+        self.connect_neurons(self.sync2, self.output_plus, "V", we, 3 * Tsyn + 2 * Tneu)
         self.connect_neurons(
             self.sync1, self.output_minus, "V", we, 3 * Tsyn + 2 * Tneu
         )
@@ -129,24 +112,20 @@ if __name__ == "__main__":
     sim.simulate(simulation_time=300)
 
     # --- Output Decoding ---
-    spikes_plus = sim.spike_log.get(net.output.id, [])
-    spikes_minus = sim.spike_log.get(net.output_alt.id, [])
+    spikes_plus = sim.spike_log.get(net.output.uid, [])
+    spikes_minus = sim.spike_log.get(net.output_alt.uid, [])
     # print(spikes_plus)
     # print(spikes_minus)
     if len(spikes_plus) >= 2:
         interval = spikes_plus[1] - spikes_plus[0]
         decoded = decode_interval_to_value(interval, encoder)
         print(f"✅ Output: x1 - x2 = {x1 - x2:.3f}")
-        print(
-            f"✅ output+ interval = {interval:.3f} ms → decoded = {decoded:.3f}"
-        )
+        print(f"✅ output+ interval = {interval:.3f} ms → decoded = {decoded:.3f}")
     elif len(spikes_minus) >= 2:
         interval = spikes_minus[1] - spikes_minus[0]
         decoded = decode_interval_to_value(interval, encoder)
         print(f"✅ Output: x1 - x2 = {x1 - x2:.3f}")
-        print(
-            f"✅ output- interval = {interval:.3f} ms → decoded = -{decoded:.3f}"
-        )
+        print(f"✅ output- interval = {interval:.3f} ms → decoded = -{decoded:.3f}")
     elif len(spikes_plus) == 1 and len(spikes_minus) == 0:
         print(f"✅ Output: Equal inputs detected (x1 = x2 = {x1})")
         print(f"✅ Single spike on output+ (zero case) → zero difference")

--- a/stick_emulator/networks/memory/constant.py
+++ b/stick_emulator/networks/memory/constant.py
@@ -19,19 +19,15 @@ class ConstantNetwork(SpikingNetworkModule):
         f_x = (value * self.encoder.Tcod) + encoder.Tmin
 
         # Create constant neuron
-        self.recall_neuron = ExplicitNeuron(
-            Vt=Vt, tm=tm, tf=tf, Vreset=0.0, neuron_id="recall"
+        self.recall_neuron = self.add_neuron(
+            Vt=Vt, tm=tm, tf=tf, Vreset=0.0, neuron_name="recall"
         )
-        self.output_neuron = ExplicitNeuron(
-            Vt=Vt, tm=tm, tf=tf, Vreset=0.0, neuron_id="output"
+        self.output_neuron = self.add_neuron(
+            Vt=Vt, tm=tm, tf=tf, Vreset=0.0, neuron_name="output"
         )
-        self.add_neurons(self.recall_neuron)
-        self.add_neurons(self.output_neuron)
 
         # Connect constant neuron to itself with a delay
-        self.connect_neurons(
-            self.recall_neuron, self.output_neuron, "V", we, Tsyn
-        )
+        self.connect_neurons(self.recall_neuron, self.output_neuron, "V", we, Tsyn)
         self.connect_neurons(
             self.recall_neuron, self.output_neuron, "V", we, Tsyn + f_x
         )
@@ -47,6 +43,6 @@ if __name__ == "__main__":
     sim = Simulator(constant_network, encoder)
     sim.apply_input_spike(constant_network.recall_neuron, t=0)
     sim.simulate(simulation_time=100)
-    output_spikes = sim.spike_log[constant_network.output_neuron.id]
+    output_spikes = sim.spike_log[constant_network.output_neuron.uid]
     print(f"Input value: {value}")
     print(f"Output spikes: {output_spikes}")

--- a/stick_emulator/networks/memory/inverting_memory.py
+++ b/stick_emulator/networks/memory/inverting_memory.py
@@ -20,12 +20,12 @@ class InvertingMemoryNetwork(SpikingNetworkModule):
         Tmin = encoder.Tmin
         Tneu = 0.01
 
-        input = ExplicitNeuron(Vt=Vt, tm=tm, tf=tf, neuron_id="input")
-        first = ExplicitNeuron(Vt=Vt, tm=tm, tf=tf, neuron_id="first")
-        last = ExplicitNeuron(Vt=Vt, tm=tm, tf=tf, neuron_id="last")
-        acc = ExplicitNeuron(Vt=Vt, tm=tm, tf=tf, neuron_id="acc")
-        recall = ExplicitNeuron(Vt=Vt, tm=tm, tf=tf, neuron_id="recall")
-        output = ExplicitNeuron(Vt=Vt, tm=tm, tf=tf, neuron_id="output")
+        input = self.add_neuron(Vt=Vt, tm=tm, tf=tf, neuron_name="input")
+        first = self.add_neuron(Vt=Vt, tm=tm, tf=tf, neuron_name="first")
+        last = self.add_neuron(Vt=Vt, tm=tm, tf=tf, neuron_name="last")
+        acc = self.add_neuron(Vt=Vt, tm=tm, tf=tf, neuron_name="acc")
+        recall = self.add_neuron(Vt=Vt, tm=tm, tf=tf, neuron_name="recall")
+        output = self.add_neuron(Vt=Vt, tm=tm, tf=tf, neuron_name="output")
 
         self.connect_neurons(input, first, "V", we, Tsyn)
         self.connect_neurons(input, last, "V", 0.5 * we, Tsyn)
@@ -35,8 +35,6 @@ class InvertingMemoryNetwork(SpikingNetworkModule):
         self.connect_neurons(recall, acc, "ge", wacc, Tsyn)
         self.connect_neurons(acc, output, "V", we, Tsyn)
         self.connect_neurons(recall, output, "V", we, 2 * Tsyn + Tneu)
-
-        self.add_neurons([input, first, last, acc, recall, output])
 
         self.input = input
         self.output = output

--- a/stick_emulator/networks/memory/memory.py
+++ b/stick_emulator/networks/memory/memory.py
@@ -21,18 +21,14 @@ class MemoryNetwork(SpikingNetworkModule):
         wacc = Vt * tm / encoder.Tmax
 
         # Create Neurons
-        input = ExplicitNeuron(Vt=Vt, tm=tm, tf=tf, neuron_id="input" + suffix)
-        first = ExplicitNeuron(Vt=Vt, tm=tm, tf=tf, neuron_id="first" + suffix)
-        last = ExplicitNeuron(Vt=Vt, tm=tm, tf=tf, neuron_id="last" + suffix)
-        acc = ExplicitNeuron(Vt=Vt, tm=tm, tf=tf, neuron_id="acc" + suffix)
-        acc2 = ExplicitNeuron(Vt=Vt, tm=tm, tf=tf, neuron_id="acc2" + suffix)
-        recall = ExplicitNeuron(
-            Vt=Vt, tm=tm, tf=tf, neuron_id="recall" + suffix
-        )
-        ready = ExplicitNeuron(Vt=Vt, tm=tm, tf=tf, neuron_id="ready" + suffix)
-        output = ExplicitNeuron(
-            Vt=Vt, tm=tm, tf=tf, neuron_id="output" + suffix
-        )
+        input = self.add_neuron(Vt=Vt, tm=tm, tf=tf, neuron_name="input" + suffix)
+        first = self.add_neuron(Vt=Vt, tm=tm, tf=tf, neuron_name="first" + suffix)
+        last = self.add_neuron(Vt=Vt, tm=tm, tf=tf, neuron_name="last" + suffix)
+        acc = self.add_neuron(Vt=Vt, tm=tm, tf=tf, neuron_name="acc" + suffix)
+        acc2 = self.add_neuron(Vt=Vt, tm=tm, tf=tf, neuron_name="acc2" + suffix)
+        recall = self.add_neuron(Vt=Vt, tm=tm, tf=tf, neuron_name="recall" + suffix)
+        ready = self.add_neuron(Vt=Vt, tm=tm, tf=tf, neuron_name="ready" + suffix)
+        output = self.add_neuron(Vt=Vt, tm=tm, tf=tf, neuron_name="output" + suffix)
 
         # Connections from input
         self.connect_neurons(input, first, "V", we, Tsyn)
@@ -61,9 +57,6 @@ class MemoryNetwork(SpikingNetworkModule):
 
         # Ready → acc2
         self.connect_neurons(acc, ready, "V", we, Tsyn)
-
-        # Register neurons
-        self.add_neurons([input, first, last, acc, acc2, recall, ready, output])
 
         # External references
         self.input = input

--- a/stick_emulator/networks/memory/signed_constant.py
+++ b/stick_emulator/networks/memory/signed_constant.py
@@ -7,9 +7,7 @@ import math
 
 
 class SignedConstantNetwork(SpikingNetworkModule):
-    def __init__(
-        self, encoder: DataEncoder, value: float, prefix: str = ""
-    ) -> None:
+    def __init__(self, encoder: DataEncoder, value: float, prefix: str = "") -> None:
         super().__init__()
         self.encoder = encoder
         self.value = value
@@ -22,31 +20,24 @@ class SignedConstantNetwork(SpikingNetworkModule):
         f_x = (math.fabs(value) * self.encoder.Tcod) + encoder.Tmin
 
         # Create constant neuron
-        self.recall = ExplicitNeuron(
-            Vt=Vt, tm=tm, tf=tf, Vreset=0.0, neuron_id=prefix + "recall"
+        self.recall = self.add_neuron(
+            Vt=Vt, tm=tm, tf=tf, Vreset=0.0, neuron_name=prefix + "recall"
         )
-        self.output_plus = ExplicitNeuron(
-            Vt=Vt, tm=tm, tf=tf, Vreset=0.0, neuron_id=prefix + "output_plus"
+        self.output_plus = self.add_neuron(
+            Vt=Vt, tm=tm, tf=tf, Vreset=0.0, neuron_name=prefix + "output_plus"
         )
-        self.output_minus = ExplicitNeuron(
-            Vt=Vt, tm=tm, tf=tf, Vreset=0.0, neuron_id=prefix + "output_minus"
+        self.output_minus = self.add_neuron(
+            Vt=Vt, tm=tm, tf=tf, Vreset=0.0, neuron_name=prefix + "output_minus"
         )
-        self.add_neurons(self.recall)
-        self.add_neurons(self.output_plus)
-        self.add_neurons(self.output_minus)
 
         # Connect constant neuron to itself with a delay
 
         if value >= 0:
             self.connect_neurons(self.recall, self.output_plus, "V", we, Tsyn)
-            self.connect_neurons(
-                self.recall, self.output_plus, "V", we, Tsyn + f_x
-            )
+            self.connect_neurons(self.recall, self.output_plus, "V", we, Tsyn + f_x)
         else:
             self.connect_neurons(self.recall, self.output_minus, "V", we, Tsyn)
-            self.connect_neurons(
-                self.recall, self.output_minus, "V", we, Tsyn + f_x
-            )
+            self.connect_neurons(self.recall, self.output_minus, "V", we, Tsyn + f_x)
 
 
 if __name__ == "__main__":
@@ -59,6 +50,6 @@ if __name__ == "__main__":
     sim = Simulator(constant_network, encoder)
     sim.apply_input_spike(constant_network.recall, t=0)
     sim.simulate(simulation_time=120)
-    output_spikes = sim.spike_log[constant_network.output_minus.id]
+    output_spikes = sim.spike_log[constant_network.output_minus.uid]
     print(f"Input value: {value}")
     print(f"Output spikes: {output_spikes}")

--- a/stick_emulator/networks/memory/signed_memory.py
+++ b/stick_emulator/networks/memory/signed_memory.py
@@ -18,32 +18,18 @@ class SignedMemoryNetwork(SpikingNetworkModule):
         Tsyn = 1.0
 
         # Main neurons
-        input_pos = ExplicitNeuron(Vt, tm, tf, neuron_id="input+")
-        input_neg = ExplicitNeuron(Vt, tm, tf, neuron_id="input-")
-        ready_pos = ExplicitNeuron(Vt, tm, tf, neuron_id="ready+")
-        ready_neg = ExplicitNeuron(Vt, tm, tf, neuron_id="ready-")
-        recall = ExplicitNeuron(Vt, tm, tf, neuron_id="recall")
-        output_pos = ExplicitNeuron(Vt, tm, tf, neuron_id="output+")
-        output_neg = ExplicitNeuron(Vt, tm, tf, neuron_id="output-")
-        ready_out = ExplicitNeuron(Vt, tm, tf, neuron_id="ready")
+        input_pos = self.add_neuron(Vt, tm, tf, neuron_name="input+")
+        input_neg = self.add_neuron(Vt, tm, tf, neuron_name="input-")
+        ready_pos = self.add_neuron(Vt, tm, tf, neuron_name="ready+")
+        ready_neg = self.add_neuron(Vt, tm, tf, neuron_name="ready-")
+        recall = self.add_neuron(Vt, tm, tf, neuron_name="recall")
+        output_pos = self.add_neuron(Vt, tm, tf, neuron_name="output+")
+        output_neg = self.add_neuron(Vt, tm, tf, neuron_name="output-")
+        ready_out = self.add_neuron(Vt, tm, tf, neuron_name="ready")
 
         # Internal memory block
         self.mem = MemoryNetwork(encoder)
         self.add_subnetwork(self.mem)
-
-        # Add all external neurons
-        self.add_neurons(
-            [
-                input_pos,
-                input_neg,
-                ready_pos,
-                ready_neg,
-                recall,
-                output_pos,
-                output_neg,
-                ready_out,
-            ]
-        )
 
         # === Connections from inputs to ready
         self.connect_neurons(input_pos, ready_pos, "V", we, Tsyn)

--- a/stick_emulator/primitives/__init__.py
+++ b/stick_emulator/primitives/__init__.py
@@ -1,4 +1,4 @@
 from .elements import ExplicitNeuron, AbstractNeuron, Synapse
 from .encoders import DataEncoder
 from .events import SpikeEvent, SpikeEventQueue, EventQueue
-from .networks import SpikingNetworkModule, AbstractSpikingNetwork
+from .networks import SpikingNetworkModule

--- a/stick_emulator/primitives/elements.py
+++ b/stick_emulator/primitives/elements.py
@@ -2,8 +2,11 @@ from .helpers import flatten_nested_list
 
 from typing import Optional
 
+
 class AbstractNeuron:
-    def __init__(self, Vt, tm, tf, Vreset=0.0):
+    _instance_count = 0
+
+    def __init__(self, Vt, tm, tf, Vreset=0.0, neuron_name: Optional[str] = None):
         """
         Initialize the neuron with given parameters.
 
@@ -23,6 +26,13 @@ class AbstractNeuron:
         self.ge = 0.0
         self.gf = 0.0
         self.gate = 0
+
+        self._uid = f"{neuron_name + '_' if neuron_name else ''}(n{AbstractNeuron._instance_count})"
+        AbstractNeuron._instance_count += 1
+
+    @property
+    def uid(self) -> str:
+        return self._uid
 
     def update(self, dt) -> bool:
         """
@@ -96,14 +106,11 @@ class ExplicitNeuron(AbstractNeuron):
         tm: float,
         tf: float,
         Vreset: float = 0.0,
-        neuron_id: Optional[str] = None,
+        neuron_name: Optional[str] = None,
     ):
-        super().__init__(Vt, tm, tf, Vreset)
-        self.id = neuron_id
+        super().__init__(Vt, tm, tf, Vreset, neuron_name)
         self.spike_times: list[float] = []
         self.out_synapses: list[Synapse] = []
-    
-        self.id = neuron_id
 
     def reset(self):
         self.V = self.Vreset

--- a/stick_emulator/primitives/events.py
+++ b/stick_emulator/primitives/events.py
@@ -49,10 +49,8 @@ class EventQueue:
     def __init__(self):
         self.events = []
 
-    def add_event(self, event_time, neuron_id, synapse_type, weight):
-        heapq.heappush(
-            self.events, (event_time, neuron_id, synapse_type, weight)
-        )
+    def add_event(self, event_time, neuron_uid, synapse_type, weight):
+        heapq.heappush(self.events, (event_time, neuron_uid, synapse_type, weight))
 
     def pop_events(self, current_time):
         events = []

--- a/stick_emulator/primitives/helpers.py
+++ b/stick_emulator/primitives/helpers.py
@@ -1,4 +1,4 @@
-def flatten_nested_list(nested_list:list) -> list:
+def flatten_nested_list(nested_list: list) -> list:
     flat_list = []
     for item in nested_list:
         if isinstance(item, list):

--- a/stick_emulator/simulator.py
+++ b/stick_emulator/simulator.py
@@ -40,16 +40,16 @@ class Simulator:
                         self.event_queue.add_event(time=t+synapse.delay, neuron=synapse.post_neuron, synapse_type=synapse.type, weight=synapse.weight)
 
     def log_spike(self, neuron: ExplicitNeuron, t: float) -> None:
-        if neuron.id in self.spike_log:
-            self.spike_log[neuron.id].append(t)
+        if neuron.uid in self.spike_log:
+            self.spike_log[neuron.uid].append(t)
         else:
-            self.spike_log[neuron.id] = [t]
+            self.spike_log[neuron.uid] = [t]
 
     def log_voltage(self, neuron: ExplicitNeuron, V: float) -> None:
-        if neuron.id in self.voltage_log:
-            self.voltage_log[neuron.id].append(V)
+        if neuron.uid in self.voltage_log:
+            self.voltage_log[neuron.uid].append(V)
         else:
-            self.voltage_log[neuron.id] = [V]
+            self.voltage_log[neuron.uid] = [V]
 
     def visualize_dynamics(self):
         print('vis')

--- a/stick_emulator/tests/test_inverting_memory.py
+++ b/stick_emulator/tests/test_inverting_memory.py
@@ -13,7 +13,7 @@ def encode_and_recall(input_value, encoder):
     sim.apply_input_spike(net.recall, t=200)
     sim.simulate(simulation_time=500)
 
-    output_spike_log = sim.spike_log[net.output.id]
+    output_spike_log = sim.spike_log[net.output.uid]
     return output_spike_log
 
 
@@ -63,9 +63,7 @@ def test_custom_encoder_parameters(Tmin, Tcod, input_value, expected_interval):
     output_spikes = encode_and_recall(input_value, custom_encoder)
 
     expected_value = custom_encoder.decode_interval(expected_interval)
-    decoded_value = custom_encoder.decode_interval(
-        output_spikes[1] - output_spikes[0]
-    )
+    decoded_value = custom_encoder.decode_interval(output_spikes[1] - output_spikes[0])
 
     assert (
         len(output_spikes) == 2

--- a/stick_emulator/tests/test_memory.py
+++ b/stick_emulator/tests/test_memory.py
@@ -16,7 +16,7 @@ def encode_and_recall(input_value, encoder):
     sim.apply_input_spike(net.recall, t=200)
     sim.simulate(simulation_time=800)
 
-    output_spike_log = sim.spike_log[net.output.id]
+    output_spike_log = sim.spike_log[net.output.uid]
     LOGGER.info(f"Output spike log: {output_spike_log}")
     return output_spike_log
 
@@ -68,9 +68,7 @@ def test_custom_encoder_parameters(Tmin, Tcod, input_value, expected_interval):
     print(output_spikes)
 
     expected_value = custom_encoder.decode_interval(expected_interval)
-    decoded_value = custom_encoder.decode_interval(
-        output_spikes[1] - output_spikes[0]
-    )
+    decoded_value = custom_encoder.decode_interval(output_spikes[1] - output_spikes[0])
 
     assert (
         len(output_spikes) == 2

--- a/stick_emulator/tests/test_primitives.py
+++ b/stick_emulator/tests/test_primitives.py
@@ -6,8 +6,7 @@ def test_basic_module():
     class MockModule(SpikingNetworkModule):
         def __init__(self):
             super().__init__()
-            neuron = ExplicitNeuron(Vt=0, tm=0, tf=0, neuron_id="neuron1")
-            self.add_neurons(neuron)
+            self.neuron = self.add_neuron(Vt=0, tm=0, tf=0, neuron_name="neuron1")
 
     module = MockModule()
 
@@ -19,15 +18,13 @@ def test_deep_module():
     class MockModule(SpikingNetworkModule):
         def __init__(self):
             super().__init__()
-            neuron = ExplicitNeuron(Vt=0, tm=0, tf=0, neuron_id="neuron1")
-            self.add_neurons(neuron)
+            self.add_neuron(Vt=0, tm=0, tf=0, neuron_name="neuron1")
 
     class WrapModule(SpikingNetworkModule):
         def __init__(self):
             super().__init__()
             mock_module = MockModule()
-            neuron = ExplicitNeuron(Vt=0, tm=0, tf=0, neuron_id="neuron2")
-            self.add_neurons(neuron)
+            self.add_neuron(Vt=0, tm=0, tf=0, neuron_name="neuron2")
             self.add_subnetwork(mock_module)
 
     module = WrapModule()
@@ -40,25 +37,20 @@ def test_deeper_module():
     class MockModule(SpikingNetworkModule):
         def __init__(self):
             super().__init__()
-            neuron = ExplicitNeuron(Vt=0, tm=0, tf=0, neuron_id="neuron1")
-            self.add_neurons(neuron)
+            self.add_neuron(Vt=0, tm=0, tf=0, neuron_name="neuron1")
 
     class Wrap1Module(SpikingNetworkModule):
         def __init__(self):
             super().__init__()
             mock_module = MockModule()
-            neuron = ExplicitNeuron(Vt=0, tm=0, tf=0, neuron_id="neuron2")
-
-            self.add_neurons(neuron)
+            self.add_neuron(Vt=0, tm=0, tf=0, neuron_name="neuron2")
             self.add_subnetwork(mock_module)
 
     class Wrap2Module(SpikingNetworkModule):
         def __init__(self):
             super().__init__()
             wrap_module = Wrap1Module()
-            neuron = ExplicitNeuron(Vt=0, tm=0, tf=0, neuron_id="neuron3")
-
-            self.add_neurons(neuron)
+            self.add_neuron(Vt=0, tm=0, tf=0, neuron_name="neuron3")
             self.add_subnetwork(wrap_module)
 
     module = Wrap2Module()

--- a/stick_emulator/tests/test_signed_memory.py
+++ b/stick_emulator/tests/test_signed_memory.py
@@ -17,9 +17,9 @@ def encode_and_recall(input_value, is_positive, encoder):
     sim.simulate(simulation_time=800)
 
     output_spikes = (
-        sim.spike_log.get(net.output_pos.id, [])
+        sim.spike_log.get(net.output_pos.uid, [])
         if is_positive
-        else sim.spike_log.get(net.output_neg.id, [])
+        else sim.spike_log.get(net.output_neg.uid, [])
     )
     return output_spikes
 
@@ -65,11 +65,11 @@ def test_signed_memory_spike_times(input_value, expected_interval):
     ), f"Expected decoded value {expected_value_neg}, got {decoded_value_neg}"
 
 
-def test_no_spikes_for_invalid_input():
+def test_no_spikes_for_inval_input():
     encoder = DataEncoder()
     net = SignedMemoryNetwork(encoder)
     with pytest.raises(Exception):
-        net.apply_input_spike(1.5)  # invalid (>1.0)
+        net.apply_input_spike(1.5)  # inval (>1.0)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Each neuron will have a `.uid`, a combination of the name assigned to the neuron and a counter that assigns a different value to each instance. The same applies to Spiking Network Modules, which also have a `.uid`.

To add neurons to modules, a new method `add_neuron()` is exposed. This simplifies the process of adding neurons but also makes sure that neurons obtain a prefix in their name indicating the module they belong to.

For example:
-> `m = MyModule(module_name='mymod')`
-> `m.uid` -> `mymod_(m0)` where (m0) indicates it's module #0
-> `n = m.add_neuron(..., neuron_name='myneu')`
-> `n.uid` -> `mymod_(m0)_myneu_(n0)` where (n0) indicates it's neuron #0